### PR TITLE
Improve ual_teleop functionalities

### DIFF
--- a/ual_teleop/config/ds4.yaml
+++ b/ual_teleop/config/ds4.yaml
@@ -1,0 +1,75 @@
+joy_layout:
+  a:
+    type: button
+    index: 1
+  b:
+    type: button
+    index: 2
+  x:
+    type: button
+    index: 0
+  y:
+    type: button
+    index: 3
+
+  left_shoulder:
+    type: button
+    index: 4
+
+  right_shoulder:
+    type: button
+    index: 5
+
+  left_trigger:
+    type: button
+    index: 6
+
+  right_trigger:
+    type: button
+    index: 7
+
+  select:
+    type: button
+    index: 8
+
+  start:
+    type: button
+    index: 9
+
+  left_thumb:
+    type: button
+    index: 10
+
+  right_thumb:
+    type: button
+    index: 11
+
+  left_analog_x:
+    type: axis
+    index: 0
+    reversed: true
+
+  left_analog_y:
+    type: axis
+    index: 1
+    reversed: false
+
+  right_analog_x:
+    type: axis
+    index: 5
+    reversed: true
+
+  right_analog_y:
+    type: axis
+    index: 2
+    reversed: false
+
+  dpad_x:
+    type: axis
+    index: 5
+    reversed: true
+
+  dpad_y:
+    type: axis
+    index: 6
+    reversed: false


### PR DESCRIPTION
I added the following improvements:
- Support for Dualshock4 (Ps4) controllers 
- Different velocity levels (changed with left and right triggers)
- "Natural" control of the drone (non-headless mode) -> activated and deactivated with right shoulder
- More vervosity (ie: Landing and taking off status)
- Safer land and take off routines: services cannot be called if drone is not flying or landed, respectively